### PR TITLE
FIX

### DIFF
--- a/src/RouteList.php
+++ b/src/RouteList.php
@@ -9,6 +9,12 @@ class RouteList extends \Nette\Application\Routers\RouteList
 {
 	private ?Translator $translator = null;
 
+	/**
+	 * Kvůli laděnce
+	 * @var string|null
+	 */
+	public $path;
+
 	public function __construct(string $module = null, ?Translator $translator = null)
 	{
 		parent::__construct($module);


### PR DESCRIPTION
Nette\MemberAccessException: Cannot read an undeclared property ADT\Routing\RouteList::$path. in /var/www/html/vendor/nette/utils/src/Utils/ObjectHelpers.php:34